### PR TITLE
 Fix GitHub language stats to prioritize Dart

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Prioritize Dart for GitHub language stats
+*.dart linguist-detectable=true
+lib/** linguist-language=Dart
+
+# Ignore platform-specific boilerplate from stats
+android/** linguist-vendored
+ios/** linguist-vendored
+macos/** linguist-vendored
+web/** linguist-vendored
+windows/** linguist-vendored
+linux/** linguist-vendored
+build/** linguist-vendored
+
+# Ignore generated files
+.flutter-plugins-dependencies linguist-generated


### PR DESCRIPTION
Added .gitattributes file to improve GitHub language detection.

- Marked Dart files as linguist-detectable
- Excluded platform-specific directories (android, ios, web, etc.)
- Excluded generated and build files

This ensures GitHub correctly shows this project as a Dart-based Flutter UI kit.